### PR TITLE
Patch GetAttackSpeedMult

### DIFF
--- a/nvse_plugin_example/hooks.cpp
+++ b/nvse_plugin_example/hooks.cpp
@@ -322,18 +322,18 @@ bool HasAnimBaseDuplicate(AnimSequenceBase* base, const BSAnimGroupSequence* ani
 	return false;
 }
 
-bool __cdecl RemoveDuplicateAnimsHook(void* aTypeBSAnimGroupSequence, BSAnimGroupSequence* arg1)
-{
+// 0x490A35
+void RemoveDuplicateAnimsHook() {
 	auto* addrOfRetn = static_cast<UInt32*>(_AddressOfReturnAddress());
 	auto* base = GET_CALLER_VAR(AnimSequenceBase*, -0x10);
 	const auto* kfModel = GET_CALLER_VAR(KFModel*, 0x8);
 	const auto* anim = kfModel->controllerSequence;
-	if (HasAnimBaseDuplicate(base, anim))
-	{
+	if (HasAnimBaseDuplicate(base, anim)){
 		*addrOfRetn = 0x490D7E;
-		return false;
+	} else {
+		// This hook replaces an opcode that takes 7 bytes, so return to next valid ins
+		*addrOfRetn = 0x490A3C;
 	}
-	return CdeclCall<bool>(0x43B300, aTypeBSAnimGroupSequence, arg1);
 }
 
 namespace LoopingReloadPauseFix
@@ -721,7 +721,7 @@ void ApplyHooks()
 	}), &uiBSTaskletSetDataAddr2);
 
 
-	WriteRelCall(0x490A45, RemoveDuplicateAnimsHook);
+	WriteRelCall(0x490A35, RemoveDuplicateAnimsHook);
 
 	// AnimData::GetNextWeaponSequenceKey
 	// fixes respectEndKey not working for a: keys

--- a/nvse_plugin_example/hooks.cpp
+++ b/nvse_plugin_example/hooks.cpp
@@ -955,6 +955,28 @@ void ApplyHooks()
 		OnActorUpdateAnimation::Dispatch(actor);
 		ThisStdCall(uiAnimDataUpdateControllersAddr, animData, actor);
 	}), &uiAnimDataUpdateControllersAddr);
+
+	static UInt32 uiGetAttackSpeedMultGetAnimAddr;
+	WriteRelCall(0x645DE0, INLINE_HOOK(Animation*, __fastcall, PlayerCharacter *pc, void*, bool bFirstPerson)
+	{
+		return ThisStdCall<Animation*>(0x950A60, pc, !pc->isInThirdPerson);
+	}), &uiGetAttackSpeedMultGetAnimAddr);
+
+	static UInt32 uiGetAttackSpeedMultGetGroupAddr;
+	WriteRelCall(0x645F51, INLINE_HOOK(uint32_t, __cdecl, uint32_t a1)
+	{
+		return CdeclCall<uint32_t>(0x5F2440, a1) & 0xFF;
+	}), & uiGetAttackSpeedMultGetGroupAddr);
+
+	static UInt32 uiGetAttackSpeedMultGetAnimAttackMultAddr;
+	WriteRelCall(0x645EE0, INLINE_HOOK(double, __fastcall, TESObjectWEAP* weap, void*, bool hasMod)
+	{
+		if (GET_CALLER_VAR_LAMBDA(Actor*, 0x8) == PlayerCharacter::GetSingleton()) {
+			return ThisStdCall<double>(0x646020, weap, false);
+		}
+
+		return ThisStdCall<double>(0x646020, weap, hasMod);
+	}), &uiGetAttackSpeedMultGetAnimAttackMultAddr);
 }
 
 void WriteDelayedHooks()


### PR DESCRIPTION
Patch GetAttackSpeedMult to report the correct values with kNVSE.  It was not considering evaluating the kNVSE anim group ids.  It will also now take into consideration if the player is in first person or third person, and eval the correct anim.

Third hook fix vanilla calculation of weapon mod effect on anim speed. This seems to only be used for visual purposes (pipboy dps calc) on the player, so to avoid affecting other actors I restricted this fix to only the player.