### PR TITLE
Fix to CopyAnimationsToForm, PluginOverrideFormAnimation, and NI_DYNAMIC_CAST

### DIFF
--- a/nvse/nvse/NiTypes.h
+++ b/nvse/nvse/NiTypes.h
@@ -4,7 +4,7 @@
 #include "Utilities.h"
 
 #define ASSERT_SIZE(name, size) static_assert(sizeof(name) == size, "Size mismatch for " #name)
-#define NI_DYNAMIC_CAST(type, ptr) ptr ? ThisStdCall<type*>(0x653290, ptr, type::ms_RTTI) : nullptr
+#define NI_DYNAMIC_CAST(type, ptr) (((ptr)) ? ThisStdCall<type*>(0x653290, (ptr), type::ms_RTTI) : nullptr)
 
 #define NIRTTI_ADDRESS(address) \
 	static inline const NiRTTI* const ms_RTTI = (NiRTTI*)address;


### PR DESCRIPTION
-Updated PluginOverrideFormAnimation so it can handle folders as well as file paths.
-Fixed CopyAnimationsToForm copying anims to stack in incorrect order.
-Updated NI_DYNAMIC_CAST Macro to be safer to use -This was causing a compiling error on the latest build tools of MSVC.